### PR TITLE
Fix table scroll to top on field select

### DIFF
--- a/frontend/src/components/admin/ClientsTable.jsx
+++ b/frontend/src/components/admin/ClientsTable.jsx
@@ -99,6 +99,7 @@ const ProfessionalTable = () => {
   const animatingProfileRef = useRef(null);
   const expandedViewRef = useRef(null);
   const tableContainerRef = useRef(null);
+  const infoCardsScrollRef = useRef(null);
 
   // Sample data with additional status field
   const [data, setdata] = useState([]);
@@ -882,6 +883,12 @@ const ProfessionalTable = () => {
   const renderInfoCards = () => memoizedInfoCards;
   const renderDocumentCards = () => memoizedDocumentCards;
 
+  useEffect(() => {
+    if (infoCardsScrollRef.current) {
+      infoCardsScrollRef.current.scrollTop = 0;
+    }
+  }, [selectedUser, pendingRequestsTab]);
+
   const renderStepContent = () => {
     if (!selectedUser) return null;
 
@@ -1143,8 +1150,7 @@ const ProfessionalTable = () => {
                     </div>
 
                     {/* Tab Content */}
-                    <div className="flex-1 overflow-y-auto tiny-scrollbar">
-                     <div className="flex-1 overflow-y-auto tiny-scrollbar">
+                    <div className="flex-1 overflow-y-auto tiny-scrollbar" ref={infoCardsScrollRef}>
   <div className={pendingRequestsTab === "info" ? "block" : "hidden"}>
     {renderInfoCards()}
   </div>


### PR DESCRIPTION
Prevent unwanted scroll-to-top in info cards when selecting fields.

The previous behavior caused the info cards section to scroll to the top whenever a field was selected or deselected. This PR introduces a ref to the scrollable container and a `useEffect` to control the scroll position, ensuring it only scrolls to the top when the `selectedUser` or `pendingRequestsTab` changes, thus maintaining the scroll position during field selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-620cb9a8-3e76-4498-b93b-a114f76b8b60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-620cb9a8-3e76-4498-b93b-a114f76b8b60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

