### PR TITLE
Fix table scroll to top on field select

### DIFF
--- a/frontend/src/components/admin/ClientsTable.jsx
+++ b/frontend/src/components/admin/ClientsTable.jsx
@@ -99,6 +99,7 @@ const ProfessionalTable = () => {
   const animatingProfileRef = useRef(null);
   const expandedViewRef = useRef(null);
   const tableContainerRef = useRef(null);
+  const infoScrollRef = useRef(null);
 
   // Sample data with additional status field
   const [data, setdata] = useState([]);
@@ -222,6 +223,23 @@ const ProfessionalTable = () => {
           acceptedfields: [...prev.acceptedfields, field],
         }));
       }
+    }
+  };
+
+  const handleFieldCardToggle = (fieldKey) => {
+    const container = infoScrollRef.current;
+    const previousScrollTop = container ? container.scrollTop : null;
+
+    handleCardToggle(fieldKey, "field");
+
+    if (previousScrollTop !== null) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (infoScrollRef.current) {
+            infoScrollRef.current.scrollTop = previousScrollTop;
+          }
+        });
+      });
     }
   };
 
@@ -838,7 +856,7 @@ const ProfessionalTable = () => {
             title={field.title}
             value={field.value}
             isSelected={accepted.acceptedfields.some((f) => f === field.key)}
-            onToggle={() => handleCardToggle(field.key, "field")}
+            onToggle={() => handleFieldCardToggle(field.key)}
           />
         ))}
       </div>
@@ -1143,8 +1161,7 @@ const ProfessionalTable = () => {
                     </div>
 
                     {/* Tab Content */}
-                    <div className="flex-1 overflow-y-auto tiny-scrollbar">
-                     <div className="flex-1 overflow-y-auto tiny-scrollbar">
+                    <div className="flex-1 overflow-y-auto tiny-scrollbar" ref={infoScrollRef}>
   <div className={pendingRequestsTab === "info" ? "block" : "hidden"}>
     {renderInfoCards()}
   </div>
@@ -1153,7 +1170,6 @@ const ProfessionalTable = () => {
   </div>
 </div>
                     </div>
-                  </div>
 
                   {/* Right Section - Mail Preview */}
                   <div className="w-1/2 max-h-[400px]">


### PR DESCRIPTION
Preserve scroll position in the info tab when selecting fields to prevent unwanted scroll-to-top.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e221d7b-e35d-4a1e-916f-df7081871468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e221d7b-e35d-4a1e-916f-df7081871468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

